### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/trace_event.py
+++ b/trace_event.py
@@ -55,7 +55,7 @@ def trace_can_enable():
   trace_enable will fail. Regular tracing methods, including
   trace_begin and trace_end, will simply be no-ops.
   """
-  return trace_event_impl != None
+  return trace_event_impl is not None
 
 if trace_event_impl:
   import time

--- a/trace_event_impl/log.py
+++ b/trace_event_impl/log.py
@@ -55,7 +55,7 @@ def _trace_enable(log_file=None):
     raise TraceException("Tracing control not allowed in child processes.")
   _enabled = True
   global _log_file
-  if log_file == None:
+  if log_file is None:
     if sys.argv[0] == '':
       n = 'trace_event'
     else:

--- a/trace_event_impl/log_multiprocess_io_test.py
+++ b/trace_event_impl/log_multiprocess_io_test.py
@@ -17,7 +17,7 @@ class LogMultipleProcessIOTest(TraceTest):
     self.proc = None
 
   def tearDown(self):
-    if self.proc != None:
+    if self.proc is not None:
       self.proc.kill()
 
   # Test that starting a subprocess to record into an existing tracefile works.

--- a/trace_event_impl/parsed_trace_events.py
+++ b/trace_event_impl/parsed_trace_events.py
@@ -15,7 +15,7 @@ class ParsedTraceEvents(object):
     """
     if trace_filename and events:
       raise Exception("Provide either a trace file or event list")
-    if not trace_filename and events == None:
+    if not trace_filename and events is None:
       raise Exception("Provide either a trace file or event list")
 
     if trace_filename:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:py_trace_event?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:py_trace_event?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
