### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/trace_event_impl/decorators.py
+++ b/trace_event_impl/decorators.py
@@ -58,9 +58,9 @@ def traced(*args):
           return default
 
       if is_method:
-        name = "%s.%s" % (args[0].__class__.__name__, func.__name__)
+        name = "{0!s}.{1!s}".format(args[0].__class__.__name__, func.__name__)
       else:
-        name = "%s.%s" % (func.__module__, func.__name__)
+        name = "{0!s}.{1!s}".format(func.__module__, func.__name__)
 
       # Be sure to repr before calling func, because the argument values may change.
       arg_values = {

--- a/trace_event_impl/log.py
+++ b/trace_event_impl/log.py
@@ -60,11 +60,11 @@ def _trace_enable(log_file=None):
       n = 'trace_event'
     else:
       n = sys.argv[0]
-    log_file = open("%s.json" % n, "ab", False)
-    _note("trace_event: tracelog name is %s.json" % n)
+    log_file = open("{0!s}.json".format(n), "ab", False)
+    _note("trace_event: tracelog name is {0!s}.json".format(n))
   elif isinstance(log_file, basestring):
-    _note("trace_event: tracelog name is %s" % log_file)
-    log_file = open("%s" % log_file, "ab", False)
+    _note("trace_event: tracelog name is {0!s}".format(log_file))
+    log_file = open("{0!s}".format(log_file), "ab", False)
   elif not hasattr(log_file, 'fileno'):
     raise TraceException("Log file must be None, a string, or a file-like object with a fileno()")
 
@@ -85,7 +85,7 @@ def _trace_enable(log_file=None):
          "pid": os.getpid(), "tid": threading.current_thread().ident,
          "ts": time.time(),
          "name": "process_argv", "args": {"argv": sys.argv}}
-    _log_file.write("%s\n" % json.dumps(x))
+    _log_file.write("{0!s}\n".format(json.dumps(x)))
   else:
     _note("trace_event: Opened existing tracelog")
   _log_file.flush()

--- a/trace_event_impl/log_io_test.py
+++ b/trace_event_impl/log_io_test.py
@@ -28,7 +28,7 @@ class LogIOTest(unittest.TestCase):
     self.assertTrue(len(e) > 0)
 
   def test_enable_with_implicit_filename(self):
-    expected_filename = "%s.json" % sys.argv[0]
+    expected_filename = "{0!s}.json".format(sys.argv[0])
     def do_work():
       file = tempfile.NamedTemporaryFile()
       trace_enable()

--- a/trace_event_impl/log_single_thread_test.py
+++ b/trace_event_impl/log_single_thread_test.py
@@ -63,7 +63,7 @@ class SingleThreadTest(TraceTest):
     tids = res.findThreadIds()
     self.assertEquals(1, len(tids))
     events = res.findEventsOnThread(tids[0])
-    efmt = ["%s %s" % (e["ph"], e["name"]) for e in events]
+    efmt = ["{0!s} {1!s}".format(e["ph"], e["name"]) for e in events]
     self.assertEquals(
       ["B func1",
        "B func2",

--- a/trace_event_impl/parsed_trace_events.py
+++ b/trace_event_impl/parsed_trace_events.py
@@ -40,7 +40,7 @@ class ParsedTraceEvents(object):
       try:
         events = json.loads(t)
       except ValueError:
-        raise Exception("Corrupt trace, did not parse. Value: %s" % t)
+        raise Exception("Corrupt trace, did not parse. Value: {0!s}".format(t))
 
       if 'traceEvents' in events:
         events = events['traceEvents']
@@ -61,7 +61,7 @@ class ParsedTraceEvents(object):
     self.events[i] = v
 
   def __repr__(self):
-    return "[%s]" % ",\n ".join([repr(e) for e in self.events])
+    return "[{0!s}]".format(",\n ".join([repr(e) for e in self.events]))
 
   def findProcessIds(self):
     if self.pids:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:py_trace_event?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:py_trace_event?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
